### PR TITLE
fix  add concurrent downloads

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,3 +20,5 @@ jobs:
         with:
           go-version: '>=1.18.0'
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        env:
+          SKIP: no-commit-to-branch

--- a/.github/workflows/validate-licenses.yml
+++ b/.github/workflows/validate-licenses.yml
@@ -14,6 +14,6 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: EmbarkStudios/cargo-deny-action@68cd9c5e3e16328a430a37c743167572e3243e7e # v1.5.15
+      - uses: EmbarkStudios/cargo-deny-action@64015a69ee7ee08f6c56455089cdaf6ad974fd15 # v1.6.1
         with:
           command: check ${{ matrix.checks }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
         stages:
           - commit-msg
     repo: https://github.com/commitizen-tools/commitizen
-    rev: v3.18.0
+    rev: v3.18.4
   - hooks:
       - id: fmt
       - id: cargo-check
@@ -18,7 +18,7 @@ repos:
   - hooks:
       - id: yamlfmt
     repo: https://github.com/google/yamlfmt
-    rev: v0.10.0
+    rev: v0.11.0
   - hooks:
       - args:
           - --markdown-linebreak-ext=md
@@ -27,6 +27,6 @@ repos:
       - id: check-yaml
       - exclude: .vscode
         id: check-json
-        #- id: no-commit-to-branch
+      - id: no-commit-to-branch
     repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "clap-verbosity-flag",
  "env_logger 0.11.3",
  "fake",
+ "futures",
  "humansize",
  "hyper 1.2.0",
  "log",
@@ -397,12 +398,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -410,6 +427,34 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
 
 [[package]]
 name = "futures-sink"
@@ -429,10 +474,16 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ askama = "0.12.1"
 clap = { version = "4.5.2", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
 env_logger = "0.11"
+futures = "0.3.30"
 humansize = "2.1.3"
 hyper = "1.2.0"
 log = "0.4"

--- a/blocklist-generator.toml
+++ b/blocklist-generator.toml
@@ -1,5 +1,5 @@
 [blocklists]
-hostfile_blocklist_urls = [
+hosts_file_blocklist_urls = [
   "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts;showintro=0",
   "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-gambling-porn/hosts",
   "https://raw.githubusercontent.com/anudeepND/blacklist/master/adservers.txt",

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -11,7 +11,7 @@ use url::Host;
 
 #[derive(Deserialize)]
 pub struct Blocklists {
-    pub hostfile_blocklist_urls: Vec<String>,
+    pub hosts_file_blocklist_urls: Vec<String>,
     pub domain_blocklist_urls: Vec<String>,
 }
 


### PR DESCRIPTION
# Description

Allow up to three concurrent downloads, instead or blocking on each one run in
series.

- **ci: 🐝 update GitHub workflows**
- **fix: 💫 allow up to 3 concurrent downloads**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] cargo test run with all tests passing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
